### PR TITLE
Support products with no Native CRS

### DIFF
--- a/datacube_wms/ogc_utils.py
+++ b/datacube_wms/ogc_utils.py
@@ -1,4 +1,7 @@
-from datacube_wms.wms_cfg_local import response_cfg
+try:
+    from datacube_wms.wms_cfg_local import service_cfg, layer_cfg, response_cfg
+except:
+    from datacube_wms.wms_cfg import service_cfg, layer_cfg, response_cfg
 
 
 def resp_headers(d):

--- a/datacube_wms/templates/wcs_desc_coverage.xml
+++ b/datacube_wms/templates/wcs_desc_coverage.xml
@@ -30,6 +30,7 @@
                     <gml:pos>{{ product.ranges.lon.max }} {{ product.ranges.lat.max }}</gml:pos>
                     {% endif %}
                 </gml:Envelope>
+                {% if product.native_CRS %}
                 <gml:RectifiedGrid dimension="2">
                     <gml:limits>
                         <gml:GridEnvelope>
@@ -49,6 +50,7 @@
                     <gml:offsetVector>{{ product.x_resolution }} 0</gml:offsetVector>
                     <gml:offsetVector>0 {{ product.y_resolution }}</gml:offsetVector>
                 </gml:RectifiedGrid>
+                {% endif %}
             </spatialDomain>
             <temporalDomain>
                 {% for t in product.ranges.times %}
@@ -82,7 +84,9 @@
             {% for crs in service.published_CRSs %}
                 <requestResponseCRSs>{{ crs }}</requestResponseCRSs>
             {% endfor %}
+            {% if product.native_CRS %}
             <nativeCRSs>{{ product.native_CRS }}</nativeCRSs>
+            {% endif %}
         </supportedCRSs>
         <supportedFormats nativeFormat="{{ service.native_wcs_format }}">
             {% for fmt in service.wcs_formats %}

--- a/datacube_wms/wms_layers.py
+++ b/datacube_wms/wms_layers.py
@@ -83,18 +83,21 @@ class ProductLayerDef(object):
         self.pq_manual_merge = product_cfg.get("pq_manual_merge", False)
 
         # For WCS
-        self.native_CRS = self.product.definition["storage"]["crs"]
-        svc_cfg = get_service_cfg()
-        if self.native_CRS not in svc_cfg.published_CRSs:
-            raise Exception("Native CRS for product {} ({}) not in published CRSs".format(self.product_name, self.native_CRS))
-        self.native_CRS_def = svc_cfg.published_CRSs[self.native_CRS]
-        data = dc.load(self.product_name, dask_chunks={})
-        self.grid_high_x = len(data[svc_cfg.published_CRSs[self.native_CRS]["horizontal_coord"]])
-        self.grid_high_y = len(data[svc_cfg.published_CRSs[self.native_CRS]["vertical_coord"]])
-        self.origin_x = data.affine[3]
-        self.origin_y = data.affine[5]
-        self.resolution_x = data.affine[0]
-        self.resolution_y = data.affine[4]
+        try:
+            self.native_CRS = self.product.definition["storage"]["crs"]
+            svc_cfg = get_service_cfg()
+            if self.native_CRS not in svc_cfg.published_CRSs:
+                raise Exception("Native CRS for product {} ({}) not in published CRSs".format(self.product_name, self.native_CRS))
+            self.native_CRS_def = svc_cfg.published_CRSs[self.native_CRS]
+            data = dc.load(self.product_name, dask_chunks={})
+            self.grid_high_x = len(data[svc_cfg.published_CRSs[self.native_CRS]["horizontal_coord"]])
+            self.grid_high_y = len(data[svc_cfg.published_CRSs[self.native_CRS]["vertical_coord"]])
+            self.origin_x = data.affine[3]
+            self.origin_y = data.affine[5]
+            self.resolution_x = data.affine[0]
+            self.resolution_y = data.affine[4]
+        except:
+            self.native_CRS = None
         bands = dc.list_measurements().ix[self.product_name]
         self.bands = bands.index.values
         self.nodata_values = bands['nodata'].values


### PR DESCRIPTION
Some products do not have a native CRS that is valid across all datasets, for example the current Sentinel 2 NRT GeoTiffs are stored using the UTM projections which will differ depending on location.

This PR will remove the DescribeCapabilities elements that use the Native CRS, however they are optional according to the WCS 1.0 spec