### PR TITLE
Lock index to datacube version 0.2.8

### DIFF
--- a/docker/auxiliary/index/Dockerfile
+++ b/docker/auxiliary/index/Dockerfile
@@ -1,4 +1,4 @@
-FROM opendatacube/wms:latest
+FROM opendatacube/wms:0.2.8
 
 RUN pip3 install \
     ruamel.yaml \


### PR DESCRIPTION
Newest datacube version removes scripts that were required for index.