### PR TITLE
Change default resampling method to nearest neighbor

### DIFF
--- a/datacube_wms/data.py
+++ b/datacube_wms/data.py
@@ -132,7 +132,7 @@ class DataStacker():
         if resampling:
             self._resampling = resampling
         else:
-            self._resampling = Resampling.average
+            self._resampling = Resampling.nearest
 
         if style:
             self._needed_bands = style.needed_bands

--- a/datacube_wms/wms_utils.py
+++ b/datacube_wms/wms_utils.py
@@ -281,7 +281,7 @@ class GetMapParameters(GetParameters):
         self.zf = zoom_factor(args, self.crs)
 
         # Read Resampling method from config
-        self.resampling = Resampling.average
+        self.resampling = Resampling.nearest
         layer_name = unquote(self.get_raw_product(args))
         for layer in layer_cfg:
             if layer["name"] == layer_name:


### PR DESCRIPTION
The new resampling changes set the default resampling method to average, this changes them back to nearest neighbor.